### PR TITLE
fix: Add redirect_uri queryparam to google authentication endpoints

### DIFF
--- a/src/auth/google/google_oauth.py
+++ b/src/auth/google/google_oauth.py
@@ -10,33 +10,32 @@ class GoogleOAuth2(object):
               'https://www.googleapis.com/auth/userinfo.email',
               'https://www.googleapis.com/auth/userinfo.profile']
 
-    def __init__(self, client_id, client_secret, http, redirect_uri):
+    def __init__(self, client_id, client_secret, http):
         self.client_id = client_id
         self.client_secret = client_secret
-        self.redirect_uri = redirect_uri
         self.http = http
 
-    def assemble_auth_server_url(self):
+    def assemble_auth_server_url(self, redirect_uri):
         url = 'https://accounts.google.com/o/oauth2/v2/auth'
         params = {
             'client_id': self.client_id,
             'access_type': 'offline',
             'response_type': 'code',
             'include_granted_scopes': 'true',
-            'redirect_uri': self.redirect_uri,
+            'redirect_uri': redirect_uri,
             'scope': ' '.join(self.SCOPES)
         }
         params = urlencode(params)
         return '{}?{}'.format(url, params)
 
-    def get_tokens(self, code):
+    def get_tokens(self, code, redirect_uri):
         url = 'https://oauth2.googleapis.com/token'
         params = {
             'client_id': self.client_id,
             'client_secret': self.client_secret,
             'grant_type': 'authorization_code',
             'code': code,
-            'redirect_uri': self.redirect_uri
+            'redirect_uri': redirect_uri
         }
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded'

--- a/src/auth/google/router.py
+++ b/src/auth/google/router.py
@@ -12,25 +12,24 @@ from src.core.config.session import db_session
 from src.auth import JWTManager
 
 router = APIRouter()
-redirect_uri = Config.HOST + '/api/v1/login/google/callback'
+default_redirect_uri = Config.HOST + '/api/v1/login/google/callback'
 google_auth = GoogleOAuth2(os.environ["GOOGLE_CLIENT_ID"],
                            os.environ["GOOGLE_CLIENT_SECRET"],
-                           requests,
-                           redirect_uri)
+                           requests)
 google_applicant_service = GoogleApplicantService(db_session)
 
 @router.get("/login/google", tags=["external_login"])
-async def get_google_auth_server_url():
-    google_auth_server_url = google_auth.assemble_auth_server_url()
+async def get_google_auth_server_url(redirect_uri=default_redirect_uri):
+    google_auth_server_url = google_auth.assemble_auth_server_url(redirect_uri)
     response = RedirectResponse(url=google_auth_server_url)
     return response
 
 @router.get('/login/google/callback', tags=["external_login_callback"])
-async def handle_google_login_response(code = None, error = None):
+async def handle_google_login_response(code = None, error = None, redirect_uri=default_redirect_uri):
     if error is not None:
         raise HTTPException(status_code=502, detail=error)
     try:
-        google_tokens_response = google_auth.get_tokens(code)
+        google_tokens_response = google_auth.get_tokens(code, redirect_uri)
         access_token = google_tokens_response.json()["access_token"]
         google_user_data = google_auth.get_user_data(access_token, ['names', 'addresses', 'residences', 'emailAddresses', 'birthdays', 'photos'])
     except requests.exceptions.ConnectionError:


### PR DESCRIPTION
This is done so in order to client-side apps can be redirected to their own apps.